### PR TITLE
Fix keyboard not dismissing on background tap

### DIFF
--- a/Core/App.swift
+++ b/Core/App.swift
@@ -8,7 +8,7 @@ struct App: SwiftUI.App {
 
     @UIApplicationDelegateAdaptor(Delegate.self)
     private var delegate
-    @ObservedObject
+    @StateObject
     private var remoteConfigCoordinator = Current.remoteConfigCoordinator
 
     init() {


### PR DESCRIPTION
I believe this to be a SwiftUI bug related to the UIApplication lifecycle and internals around retained SwiftUI state.